### PR TITLE
EVG-17966 Stopiteration exception in ftdc-tools

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,9 +12,9 @@ steps:
   image: python
   pull: if-not-exists
   commands:
-  - curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
-  - . $HOME/.poetry/env
-  - poetry install
+  - pip3 install --upgrade pip
+  - pip3 install poetry==1.2.0
+  - poetry --version
   - poetry run pytest src tests
   when:
     branch:

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,6 +15,7 @@ steps:
   - pip3 install --upgrade pip
   - pip3 install poetry==1.2.0
   - poetry --version
+  - poetry install
   - poetry run pytest src tests
   when:
     branch:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ftdc-tools"
-version = "0.3.0"
+version = "0.3.1"
 description = ""
 authors = [
     "Alexander Costas <alexander.costas@mongodb.com>",

--- a/src/ftdc_tools/decoder.py
+++ b/src/ftdc_tools/decoder.py
@@ -60,7 +60,10 @@ class FTDC(Iterable):
             raise ValueError(
                 "Async interation not supported. FTDC data is not of type AsyncIterator"
             )
-        chunk = await self.raw.__anext__()
+        try:
+            chunk = await self.raw.__anext__()
+        except StopAsyncIteration:
+            return
         next_chunk = self.raw.__anext__()
         chunks_created, chunks_awaited = 2, 1
         gen = self.getftdc(chunk)
@@ -110,7 +113,10 @@ class FTDC(Iterable):
                 if x is not None:
                     yield x
         elif isinstance(self.raw, Iterator):
-            chunk = next(self.raw)
+            try:
+                chunk = next(self.raw)
+            except StopIteration:
+                return
             gen = self.getftdc(chunk)
             more = True
             for x, doc_len, buf in gen:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,10 @@ import pytest
 def test_data() -> List[Dict[str, object]]:
     return [
         {
+            "ftdc_file": "./tests/test_bson_files/test_data_ftdc_file_empty_doc",
+            "doc_count": 0,
+        },
+        {
             "ftdc_file": "./tests/test_bson_files/test_data_ftdc_file_0_doc",
             "doc_count": 1,
         },


### PR DESCRIPTION
This was happening when the FTDC files were empty.

Since we were calling `next()` directly on the underlying iterators, we were hitting this on the initial ones